### PR TITLE
♻️ Add more naming component support

### DIFF
--- a/Sources/Stilleben/Matcher/UIKitMatcher.swift
+++ b/Sources/Stilleben/Matcher/UIKitMatcher.swift
@@ -41,7 +41,7 @@ public struct UIKitMatcher: SnapshotMatcher {
             }
             .recordingNameComponent(add: colorScheme)
             .recordingNameComponent(add: dynamicTypeSize)
-            .recordingNameComponent(add: locale.identifier)
+            .recordingNameComponent(add: locale)
             .addDeviceName(add: includeDeviceName)
             .diffUIKit(
                 file: file,

--- a/Sources/Stilleben/Snapshot/Snapshot/Snapshot+Record.swift
+++ b/Sources/Stilleben/Snapshot/Snapshot/Snapshot+Record.swift
@@ -46,4 +46,8 @@ public extension Snapshot {
     func recordingNameComponent(add dynamicTypeSize: DynamicTypeSize) -> Self {
         recordingNameComponent(add: String(describing: dynamicTypeSize))
     }
+
+    func recordingNameComponent(add locale: Locale) -> Self {
+        recordingNameComponent(add: locale.identifier)
+    }
 }


### PR DESCRIPTION
This PR adds support for passing `ColorScheme` or `DynamicTypeSize` as names.