### PR TITLE
🐛 Overriding bundle locale

### DIFF
--- a/Sources/Stilleben/Matchers/UIMatcher/UIMatcher+SwiftUI.swift
+++ b/Sources/Stilleben/Matchers/UIMatcher/UIMatcher+SwiftUI.swift
@@ -17,6 +17,8 @@ extension UIMatcher {
             }
 
         for (colorScheme, locale, dynamicTypeSize) in permutations {
+            Bundle.overrideLocale = locale
+
             await Snapshot(file: file, function: function, line: line) {
                 try await produce()
                     .ignoresSafeArea(ignoresSafeArea ? .all : [], edges: ignoresSafeArea ? .all : [])


### PR DESCRIPTION
Overriding bundle locale to make localized strings work properly in SwiftUI views